### PR TITLE
HW4

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,4 +10,5 @@ target 'VKClientApp' do
   
   pod 'RealmSwift'
   pod 'SwiftyJSON', '~> 5.0.0'
+  pod "PromiseKit", "~> 6.8"
 end

--- a/VKClientApp.xcodeproj/xcuserdata/alekseysinkarev.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/VKClientApp.xcodeproj/xcuserdata/alekseysinkarev.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>VKClientApp.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>5</integer>
+			<integer>6</integer>
 		</dict>
 	</dict>
 </dict>

--- a/VKClientApp/Controllers/FriendsViewController.swift
+++ b/VKClientApp/Controllers/FriendsViewController.swift
@@ -156,7 +156,7 @@ class FriendsViewController: UITableViewController {
 
 extension FriendsViewController {
     func getFriends() {
-        appSettings.apiService.getFriends()
+        appSettings.apiService.getFriendsByPromise()
     }
 
     func observeFriends() {


### PR DESCRIPTION
На PromiseKit  переведен запрос на получение списка друзей.
реализация в APIService: добавил новый вариант через Promises  и оставил пока старый вариант на замыканиях
вызов в FriendsViewController
Странно, что не всю ветку работы с друзьями на промисы, включая фото друзей, а один запрос, но сделал как указано в ДЗ: "Перевести на PromiseKit отправку сетевого запроса на получение друзей"