### PR TITLE
HW 6.2 proxy

### DIFF
--- a/VKClientApp.xcodeproj/project.pbxproj
+++ b/VKClientApp.xcodeproj/project.pbxproj
@@ -76,6 +76,8 @@
 		16C53F3F27450815003E19ED /* NewsLikesCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 16C53F3D27450814003E19ED /* NewsLikesCell.xib */; };
 		16C73E982791A8C400B11E45 /* NewsImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C73E972791A8C400B11E45 /* NewsImage.swift */; };
 		16CFC2DF27BAA20F00454C9B /* PhotoDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CFC2DE27BAA20F00454C9B /* PhotoDataProvider.swift */; };
+		16D0EFEA27F841FD00DDB0BC /* APIAdapterProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D0EFE927F841FD00DDB0BC /* APIAdapterProxy.swift */; };
+		16D0EFEC27F8422300DDB0BC /* APIAdapterProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D0EFEB27F8422300DDB0BC /* APIAdapterProxyProtocol.swift */; };
 		16D77D62270327E0001973DF /* SessionSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D77D61270327E0001973DF /* SessionSettings.swift */; };
 		16D89AE526E7C493000031AC /* FriendsSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D89AE426E7C493000031AC /* FriendsSectionHeader.swift */; };
 		16D89AE726E7C936000031AC /* FriendsSectionHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 16D89AE626E7C936000031AC /* FriendsSectionHeader.xib */; };
@@ -160,6 +162,8 @@
 		16C53F3D27450814003E19ED /* NewsLikesCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NewsLikesCell.xib; sourceTree = "<group>"; };
 		16C73E972791A8C400B11E45 /* NewsImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsImage.swift; sourceTree = "<group>"; };
 		16CFC2DE27BAA20F00454C9B /* PhotoDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoDataProvider.swift; sourceTree = "<group>"; };
+		16D0EFE927F841FD00DDB0BC /* APIAdapterProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIAdapterProxy.swift; sourceTree = "<group>"; };
+		16D0EFEB27F8422300DDB0BC /* APIAdapterProxyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIAdapterProxyProtocol.swift; sourceTree = "<group>"; };
 		16D77D61270327E0001973DF /* SessionSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionSettings.swift; sourceTree = "<group>"; };
 		16D89AE426E7C493000031AC /* FriendsSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsSectionHeader.swift; sourceTree = "<group>"; };
 		16D89AE626E7C936000031AC /* FriendsSectionHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FriendsSectionHeader.xib; sourceTree = "<group>"; };
@@ -309,6 +313,8 @@
 				167012B827D9F27500C26F1F /* BackendAdapter */,
 				1662A9392707592A004A52F8 /* APIService.swift */,
 				1662A93B27076694004A52F8 /* EndPoint.swift */,
+				16D0EFE927F841FD00DDB0BC /* APIAdapterProxy.swift */,
+				16D0EFEB27F8422300DDB0BC /* APIAdapterProxyProtocol.swift */,
 			);
 			path = BackendRequests;
 			sourceTree = "<group>";
@@ -613,8 +619,10 @@
 				165481B026D9606B002F8292 /* GroupsViewCell.swift in Sources */,
 				16C53F27274228C7003E19ED /* ResponseNews.swift in Sources */,
 				165481A926D95CA8002F8292 /* GroupsViewController.swift in Sources */,
+				16D0EFEC27F8422300DDB0BC /* APIAdapterProxyProtocol.swift in Sources */,
 				165D1DD8274D63D700CCAE51 /* PhotoNews.swift in Sources */,
 				16212F4627E35D19004B23D3 /* PhotoViewModelFactory.swift in Sources */,
+				16D0EFEA27F841FD00DDB0BC /* APIAdapterProxy.swift in Sources */,
 				165481A126D7CF1A002F8292 /* FriendDetailsCollectionViewController.swift in Sources */,
 				16E1B98D27B3FFEF009774B5 /* PhotoService.swift in Sources */,
 				1654819A26D6A3F8002F8292 /* Group.swift in Sources */,

--- a/VKClientApp/BackendRequests/APIAdapterProxy.swift
+++ b/VKClientApp/BackendRequests/APIAdapterProxy.swift
@@ -1,0 +1,74 @@
+//
+//  APIAdapterProxy.swift
+//  VKClientApp
+//
+//  Created by Алексей Шинкарев on 02.04.2022.
+//
+
+import Alamofire
+import os
+
+class APIAdapterProxy: APIAdapterProxyProtocol {
+    static let logger = Logger(subsystem: "com.alexey.shinkarev.VKClientApp",
+                               category: "VK REST API")
+    static let apiAdapter = APIAdapter()
+    
+    func searchGroups(searchString: String,
+                      completion: @escaping ([Group]?) -> Void)
+    {
+        APIAdapterProxy.logger.info("Search groups by \(searchString)")
+        APIAdapterProxy.apiAdapter.searchGroups(searchString: searchString,
+                                                completion: completion)
+    }
+    
+    func joinGroup(groupID: Int, completion: @escaping (Bool) -> Void) {
+        APIAdapterProxy.logger.info("Join group with ID \(groupID)")
+        APIAdapterProxy.apiAdapter.joinGroup(groupID: groupID,
+                                             completion: completion)
+    }
+    
+    func leaveGroup(groupID: Int, completion: @escaping ([Group]?) -> Void) {
+        APIAdapterProxy.logger.info("Leave group with ID \(groupID)")
+        APIAdapterProxy.apiAdapter.leaveGroup(groupID: groupID,
+                                              completion: completion)
+    }
+    
+    func getUserGroups(completion: @escaping ([Group]?) -> Void) {
+        APIAdapterProxy.logger.info("Get current user groups")
+        APIAdapterProxy.apiAdapter.getUserGroups(completion: completion)
+    }
+    
+    func getFriends(completion: @escaping ([User]?) -> Void) {
+        APIAdapterProxy.logger.info("Get current user friends")
+        APIAdapterProxy.apiAdapter.getFriends(completion: completion)
+    }
+    
+    func getUserPhotos(userID: Int, completion: @escaping ([Photo]?) -> Void) {
+        APIAdapterProxy.logger.info("Get user photo by userID \(userID)")
+        APIAdapterProxy.apiAdapter.getUserPhotos(userID: userID,
+                                                 completion: completion)
+    }
+    
+    func getNewsFeed(startTime: Int, startFrom: [PostType: String?],
+                     completion: @escaping ([PostType: ResponseNews<News>?]) -> Void)
+    {
+        APIAdapterProxy.logger.info("Get current user news by parameters start_time \(startTime), start_from {\(startFrom.map { $0.key.rawValue + " = " + ($0.value ?? "nil") }.joined(separator: ", "))}")
+        APIAdapterProxy.apiAdapter.getNewsFeed(startTime: startTime,
+                                               startFrom: startFrom,
+                                               completion: completion)
+    }
+    
+    func getImage(url: String, completion: @escaping (UIImage?) -> Void) {
+        APIAdapterProxy.logger.info("Get image by url \(url)")
+        APIAdapterProxy.apiAdapter.getImage(url: url, completion: completion)
+    }
+    
+    func loadImage(placeholderImage: UIImage?, toImageView: UIImageView?,
+                   url: String, onFailureImage: UIImage?)
+    {
+        APIAdapterProxy.logger.info("Load image from url \(url)")
+        APIAdapterProxy.apiAdapter.loadImage(placeholderImage: placeholderImage,
+                                             toImageView: toImageView, url: url,
+                                             onFailureImage: onFailureImage)
+    }
+}

--- a/VKClientApp/BackendRequests/APIAdapterProxyProtocol.swift
+++ b/VKClientApp/BackendRequests/APIAdapterProxyProtocol.swift
@@ -1,0 +1,33 @@
+//
+//  AlamofireProxyProtocol.swift
+//  VKClientApp
+//
+//  Created by Алексей Шинкарев on 02.04.2022.
+//
+
+import Alamofire
+import os
+
+protocol APIAdapterProxyProtocol {
+    static var logger: Logger { get }
+    static var apiAdapter: APIAdapter { get }
+    func searchGroups(searchString: String, completion: @escaping ([Group]?) -> Void)
+
+    func joinGroup(groupID: Int, completion: @escaping (Bool) -> Void)
+
+    func leaveGroup(groupID: Int, completion: @escaping ([Group]?) -> Void)
+
+    func getUserGroups(completion: @escaping ([Group]?) -> Void)
+
+    func getFriends(completion: @escaping ([User]?) -> Void)
+
+    func getUserPhotos(userID: Int, completion: @escaping ([Photo]?) -> Void)
+    func getNewsFeed(startTime: Int,
+                     startFrom: [PostType: String?],
+                     completion: @escaping ([PostType: ResponseNews<News>?]) -> Void)
+
+    func getImage(url: String, completion: @escaping (UIImage?) -> Void)
+
+    func loadImage(placeholderImage: UIImage?, toImageView: UIImageView?,
+                   url: String, onFailureImage: UIImage?)
+}

--- a/VKClientApp/Controllers/DataProviders/NewsDataProvider.swift
+++ b/VKClientApp/Controllers/DataProviders/NewsDataProvider.swift
@@ -7,6 +7,11 @@
 
 import Foundation
 import UIKit
+
+enum PostType: String {
+    case post = "post", photo = "photo"
+}
+
 final class NewsDataProvider {
     private let newsSectionFactory = NewsSectionFactory()
     private var controller: UITableViewController?
@@ -192,9 +197,4 @@ final class NewsDataProvider {
             .first?.getDate() ?? 0
         maxNewsTime = max(maxNewsTime ?? 0, newTime)
     }
-}
-
-enum PostType: String {
-    case post
-    case photo
 }

--- a/VKClientApp/Singletons/AppSettings.swift
+++ b/VKClientApp/Singletons/AppSettings.swift
@@ -10,7 +10,7 @@ import UIKit
 class AppSettings {
     static let instance = AppSettings()
     let apiService = APIService()
-    let apiAdapter = APIAdapter()
+    let apiAdapter = APIAdapterProxy()
     let queuedService = QueuedOperations()
     let photoService = PhotoService()
 }


### PR DESCRIPTION
ДЗ 6.2  логирующий прокси 
APIAdapterProxyProtocol - протокол прокси
APIAdapterProxy - сам логирующий прокси (подменил на него APIAdapter  в синглтоне) 
На уроке рассматривали обертку для запросов приложения. Решил, что ДЗ требует чего-то подобного. (да и быстрее это делается)
По хорошему, логирование  на уровне Alamofire нужно делать чтоб иметь возможность все параметры запросов пробрасывать в лог, но это уже много раз сделали до нас.
